### PR TITLE
clang-tidy is enabled by default

### DIFF
--- a/features.md
+++ b/features.md
@@ -40,7 +40,6 @@ and style issues.
 
 clangd respects your project's `.clang-tidy` file which controls the checks to
 run. Not all checks work within clangd.
-You must pass the `-clang-tidy` flag to enable this feature.
 
 
 ## Code completion


### PR DESCRIPTION
A user mentioned that they've read this page and thought clang-tidy wouldn't be enabled unless they say so.