### PR TITLE
Tweaks to remote index docs

### DIFF
--- a/design/indexing.md
+++ b/design/indexing.md
@@ -91,4 +91,4 @@ Remote index allows serving index on a separate machine and connecting to it
 from your device. This means you don't have to build the index yourself
 anymore and clangd will use significantly less memory. Hence developers can
 work from less powerful machines, while still using clangd to its fullest.
-For more details, see [remote index](/remote-index.md).
+For more details, see [remote index](/remote-index.html).

--- a/llvm-remote-index.md
+++ b/llvm-remote-index.md
@@ -1,14 +1,13 @@
-# LLVM remote index service
+# Unofficial LLVM remote index service
 
-There's currently a test instance of clangd remote-index for LLVM project at
-`llvm.clangd-index-staging.dev`. The service is maintained at best effort,
-and is not an official LLVM product.
+A clangd [remote index](/remote-index.html) server for the LLVM project is
+currently available for testing.
+The service is unsupported and is not an official LLVM product.
 
-After getting a clangd with remote-index support as described in
-[here](./remote-index.md#getting-remote-index-support-in-clangd), you can
-point it at `llvm.clangd-index-staging.dev:50051` either through
-[config](./config.md) or [command line
-flags](./remote-index.md#using-remote-index-feature).
+To use it, you'll need clangd with remote-index support. Set the server address
+to `llvm.clangd-index-staging.dev:50051`, and the project root to your
+`llvm-project` directory. Details on how to do this are at
+[remote index](/remote-index.html).
 
 ## Overview
 
@@ -24,44 +23,32 @@ available:
 
 The service is hosted on GCP by clangd team, with sponsorship of Google.
 
-Whole LLVM codebase (`-DLLVM_ENABLE_PROJECTS="all"`) is indexed on a daily
-basis, index snapshots are available in [clangd/llvm-remote-index
-releases](https://github.com/clangd/llvm-remote-index/releases). We only
-index the main branch of LLVM and periodically check for the new idex version
-on the deployment server. The server also checks for new versions of
-`clangd-index-server` which is fetched from [clangd/clangd
-snapshots](https://github.com/clangd/clangd/releases).
+The whole [`llvm-project`](https://github.com/llvm/llvm-project) codebase
+is indexed daily (`main` branch, `-DLLVM_ENABLE_PROJECTS="all"`).
+Index snapshots are published as [clangd/llvm-remote-index
+releases](https://github.com/clangd/llvm-remote-index/releases) and the index
+server periodically fetches the newest data.
 
 ## Privacy and security notice
 
-Remote index service is offered for free to everyone on internet, mainly
-benefiting people working on the open-source LLVM project. The service is run
-on best-effort basis and this is not an official LLVM product.
+This index service is offered for free to all developers, and is mostly useful
+to people working on the open-source LLVM project. The service is run on a
+best-effort basis and is not an official LLVM product.
+Google donated the funding for Google Cloud Platform instance that is used, but
+it is a public instance running and serving unmodified LLVM code.
 
-Source code that is served is the open source version of LLVM: sources from
-the [LLVM monorepo](https://github.com/llvm/llvm-project) main branch are
-fetched without any modifications. The infrastructure used and the code being
-run is publicly available
-([clangd/index/remote](https://github.com/llvm/llvm-project/tree/master/clang-tools-extra/clangd/index/remote)
-for server and client implementation,
-[llvm-remote-index](https://github.com/clangd/llvm-remote-index) for
-indexing, data pipelines and deployment). Google generously donated the
-funding for Google Cloud Platform instance that is used, but it is a public
-instance (same as any instance open source developers can use themselves).
-
-Requests from user contain some data from clangd instance such as the file
-you are editing, (possibly incomplete) token before the cursor and other
-index signals. Full description of transferred data is
+The requests clangd sends to server contain information about the code such as
+the file path you are editing, partial token before the cursor and other
+index signals. Request details:
 [`Index.proto`](https://github.com/llvm/llvm-project/blob/master/clang-tools-extra/clangd/index/remote/Index.proto)
 and
 [`Service.proto`](https://github.com/llvm/llvm-project/blob/master/clang-tools-extra/clangd/index/remote/Service.proto)
-files. No data is stored longer than needed and no user-specific data is
-stored at all: as soon as the request is complete we throw away the data
-keeping only the aggregate statistics (request latencies, number of requests,
-etc) and logs without any personal data to ensure service stability and
-diagnose issues. As the result, personal data is not stored anywhere.
-Aggregate data is used to track improve the state of the service, it is
-available upon request. Here is the
-[Dockerfile](https://github.com/clangd/llvm-remote-index/blob/master/deployment/Dockerfile)
-we use for running the service and [logging
-implementation](https://github.com/llvm/llvm-project/blob/master/clang-tools-extra/clangd/index/remote/server/Server.cpp).
+This data is needed to provide index results, is discarded after serving the
+request, and is not stored.
+
+Basic anonymous request information is logged to observe service level:
+ - request type (e.g. "lookup")
+ - success/failure
+ - number of results returned
+ - latency
+

--- a/remote-index.md
+++ b/remote-index.md
@@ -7,6 +7,7 @@ a shared server to host the index instead.
 ## How it works
 
 The remote index has three components:
+
  - the **indexer** is a batch process that should run on a powerful machine.
    It parses all the code for your project, and produces an index file.
  - the **server** exposes the index over a network. It loads the index file into
@@ -20,8 +21,8 @@ Each of these components are open-source and part of
 
 ## Indexer
 
-`clangd-indexer` collects symbols that can be exported from headers
-(functions, classes, types, etc).
+`clangd-indexer` collects symbols that can be exported from headers (functions,
+classes, types, etc).
 It's usually necessary to run the build system for your project first,
 to produce `compile_commands.json` and possibly generate source files.
 


### PR DESCRIPTION
- reduce duplication, particularly between llvm-remote-index and remote-index
- add introduction to remote-index, describing what the feature does
- describe three components of remote-index rather than two (client!)
- clarify support of testing instance (unsupported, not best-effort)
- more direct/concise language (e.g. indexing pipeline -> indexer)
- move a few paragraphs to more closely related sections
- make privacy section of llvm-remote-index specific and remove some subjective language
- broken links fixed (link to *.html, not *.md)