### PR TITLE
Proposed fix for typo in clangd threading docs

### DIFF
--- a/design/threads.md
+++ b/design/threads.md
@@ -64,4 +64,5 @@ parser hits it.
 
 As this doesn't reuse the AST, it can run on a separate thread rather than the
 ASTWorker. It does use the preamble, but we don't wait for it to be up-to-date.
-Since completion is extremely, it just uses whichever is immediately available.
+Since completion is extremely time sensitive, it just uses whichever is
+immediately available.


### PR DESCRIPTION
I'd noticed a missing phrase while reading through the clangd design docs, and figured I'd propose a quick fix. 

@sam-mccall, looks like you last committed to these docs, and you were the one nice enough to point me to them, so I'm going to tag you :)  At the same time, a hearty "hi" and "thank you" from an ex-Googler.