### PR TITLE
Fix CompileFlags:Add example not including a comma

### DIFF
--- a/config.md
+++ b/config.md
@@ -88,7 +88,7 @@ Affects how a source file is parsed.
 
 ```
 CompileFlags:                     # Tweak the parse settings
-  Add: [-xc++ -Wall]              # treat all files as C++, enable more warnings
+  Add: [-xc++, -Wall]              # treat all files as C++, enable more warnings
   Remove: -W*                     # strip all other warning-related flags
 ```
 

--- a/config.md
+++ b/config.md
@@ -88,7 +88,7 @@ Affects how a source file is parsed.
 
 ```
 CompileFlags:                     # Tweak the parse settings
-  Add: [-xc++, -Wall]              # treat all files as C++, enable more warnings
+  Add: [-xc++, -Wall]             # treat all files as C++, enable more warnings
   Remove: -W*                     # strip all other warning-related flags
 ```
 


### PR DESCRIPTION
This can mislead people into thinking flags don't need to be comma separated