### PR TITLE
Add Diagnostics Block to config documentation

### DIFF
--- a/config.md
+++ b/config.md
@@ -170,18 +170,37 @@ Index:
   files under the `MountPoint`. Users can turn it back on, by explicitly
   mentioning `Background: Build` in a later fragment.
 
-## ClangTidy
+## Diagnostics 
+
+{:.v12}
+
+### Suppress
+
+Diagnostic codes that should be suppressed.
+
+ Valid values are:
+ - `*`, to disable all diagnostics
+ - diagnostic codes exposed by clangd (e.g unknown_type, -Wunused-result)
+ - clang internal diagnostic codes (e.g. err_unknown_type)
+ - warning categories (e.g. unused-result)
+ - clang-tidy check names (e.g. bugprone-narrowing-conversions)
+
+This is a simple filter. Diagnostics can be controlled in other ways
+(e.g. by disabling a clang-tidy check, or the -Wunused compile flag).
+This often has other advantages, such as skipping some analysis.
+
+### ClangTidy
 
 Configure how clang-tidy runs over your files.
 
 The settings are merged with any settings found in .clang-tidy
 configuration files with the ones from clangd configs taking precedence.
 
-### Add
+#### Add
 
 List of checks to enable, can be globs.
 
-### Remove
+#### Remove
 
 List of checks to disable, can be globs.
 
@@ -195,7 +214,7 @@ Example to use all modernize module checks apart from use trailing return type:
    Remove: modernize-use-trailing-return-type
 ```
 
-### CheckOptions
+#### CheckOptions
 
 Key-value pairs of options for clang-tidy checks.
 Available options for all checks can be found [here](https://clang.llvm.org/extra/clang-tidy/checks/list.html).

--- a/config.md
+++ b/config.md
@@ -171,7 +171,6 @@ Index:
   mentioning `Background: Build` in a later fragment.
 
 ## Diagnostics 
-
 {:.v12}
 
 ### Suppress

--- a/config.md
+++ b/config.md
@@ -179,13 +179,13 @@ Diagnostic codes that should be suppressed.
 
  Valid values are:
  - `*`, to disable all diagnostics
- - diagnostic codes exposed by clangd (e.g unknown_type, -Wunused-result)
- - clang internal diagnostic codes (e.g. err_unknown_type)
- - warning categories (e.g. unused-result)
- - clang-tidy check names (e.g. bugprone-narrowing-conversions)
+ - diagnostic codes exposed by clangd (e.g `unknown_type`, `-Wunused-result`)
+ - clang internal diagnostic codes (e.g. `err_unknown_type`)
+ - warning categories (e.g. `unused-result`)
+ - clang-tidy check names (e.g. `bugprone-narrowing-conversions`)
 
 This is a simple filter. Diagnostics can be controlled in other ways
-(e.g. by disabling a clang-tidy check, or the -Wunused compile flag).
+(e.g. by disabling a clang-tidy check, or the `-Wunused` compile flag).
 This often has other advantages, such as skipping some analysis.
 
 ### ClangTidy


### PR DESCRIPTION
Add `Diagnostic` block to config and move the `ClangTidy` under there.
Also tag the block as version 12 to save confusion.