### PR TITLE
Fix github source code link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -19,7 +19,7 @@
   icon: '⊕'
 - separator
 - title: Browse code
-  url: https://github.com/llvm/llvm-project/tree/master/clang-tools-extra/clangd
+  url: https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clangd
   icon: '📄'
 - title: Bug tracker
   url: https://github.com/clangd/clangd/issues

--- a/llvm-remote-index.md
+++ b/llvm-remote-index.md
@@ -16,7 +16,7 @@ easier and make the development process more accessible. The whole service
 implementation, including infrastructure, is open source and publicly
 available:
 
-* [clangd/index/remote](https://github.com/llvm/llvm-project/tree/master/clang-tools-extra/clangd/index/remote):
+* [clangd/index/remote](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clangd/index/remote):
   `clangd-index-server` and client implementation
 * [llvm-remote-index](https://github.com/clangd/llvm-remote-index):
   indexing, data pipelines and deployment scripts
@@ -40,9 +40,9 @@ it is a public instance running and serving unmodified LLVM code.
 The requests clangd sends to server contain information about the code such as
 the file path you are editing, partial token before the cursor and other
 index signals. Request details:
-[`Index.proto`](https://github.com/llvm/llvm-project/blob/master/clang-tools-extra/clangd/index/remote/Index.proto)
+[`Index.proto`](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/index/remote/Index.proto)
 and
-[`Service.proto`](https://github.com/llvm/llvm-project/blob/master/clang-tools-extra/clangd/index/remote/Service.proto)
+[`Service.proto`](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/index/remote/Service.proto)
 This data is needed to provide index results, is discarded after serving the
 request, and is not stored.
 

--- a/remote-index.md
+++ b/remote-index.md
@@ -17,7 +17,7 @@ The remote index has three components:
    of a symbol) in real-time.
 
 Each of these components are open-source and part of
-[llvm/llvm-project/clang-tools-extra/clangd](https://github.com/llvm/llvm-project/tree/master/clang-tools-extra/clangd/).
+[llvm/llvm-project/clang-tools-extra/clangd](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clangd/).
 
 ## Indexer
 


### PR DESCRIPTION
Currently points to the now removed master branch, update it to point to main.