### PR TITLE
add Diagnostics token to ClangTidy example configs

### DIFF
--- a/config.md
+++ b/config.md
@@ -208,9 +208,10 @@ This takes precedence over Add, this supports enabling all checks from a module 
 Example to use all modernize module checks apart from use trailing return type:
 
 ```
- ClangTidy:
-   Add: modernize*
-   Remove: modernize-use-trailing-return-type
+Diagnostics:
+  ClangTidy:
+    Add: modernize*
+    Remove: modernize-use-trailing-return-type
 ```
 
 #### CheckOptions
@@ -221,7 +222,8 @@ Available options for all checks can be found [here](https://clang.llvm.org/extr
 Note the format here is slightly different to `.clang-tidy` configuration files as we don't specify `key: <key>, value: <value>`.
 Instead just use `<key>: <value>`
 ```
-ClangTidy:
-  CheckOptions:
-    readability-identifier-naming.VariableCase: CamelCase
+Diagnostics:
+  ClangTidy:
+    CheckOptions:
+      readability-identifier-naming.VariableCase: CamelCase
 ```


### PR DESCRIPTION
Just started working with clangd and copied the ClangTidy config example from this page.
I then got the following error message:

![grafik](https://user-images.githubusercontent.com/47833675/110914408-a07d0880-8316-11eb-8996-27ecc8fd1b22.png)

Compared to the Index section, the diagnostics section misses the `Diagnostics` key.
Hope this little fix helps others in the future.
