### PR TITLE
Update remote index documentation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,6 +18,13 @@
   url: /extensions.html
   icon: '⊕'
 - separator
+- title: Remote Index
+  url: /remote-index.html
+  icon: '💻'
+- title: LLVM Remote Index service
+  url: /llvm-remote-index.html
+  icon: '🐲'
+- separator
 - title: Browse code
   url: https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clangd
   icon: '📄'

--- a/llvm-remote-index.md
+++ b/llvm-remote-index.md
@@ -5,7 +5,20 @@ project](https://github.com/llvm/llvm-project) is currently available.
 
 To use it, you'll need clangd with remote-index support. Set the server address
 to `clangd-index.llvm.org:5900`, and the project root to your `llvm-project`
-directory. Details on how to do this are at [remote index](/remote-index.html).
+directory. One way of doing it would be putting this under
+`~/.config/clangd/config.yaml`:
+
+```yaml
+If:
+  PathMatch: /path/to/llvm/.*
+Index:
+  External:
+    Server: clangd-index.llvm.org:5900
+    MountPoint: /path/to/llvm/
+```
+
+For more details on remote index configuration, see [remote
+index](/remote-index.html).
 
 ## Overview
 

--- a/llvm-remote-index.md
+++ b/llvm-remote-index.md
@@ -1,13 +1,11 @@
-# Unofficial LLVM remote index service
+# LLVM remote index service
 
-A clangd [remote index](/remote-index.html) server for the LLVM project is
-currently available for testing.
-The service is unsupported and is not an official LLVM product.
+A clangd [remote index](/remote-index.html) server for the [LLVM
+project](https://github.com/llvm/llvm-project) is currently available.
 
 To use it, you'll need clangd with remote-index support. Set the server address
-to `llvm.clangd-index-staging.dev:50051`, and the project root to your
-`llvm-project` directory. Details on how to do this are at
-[remote index](/remote-index.html).
+to `clangd-index.llvm.org:5900`, and the project root to your `llvm-project`
+directory. Details on how to do this are at [remote index](/remote-index.html).
 
 ## Overview
 
@@ -33,9 +31,9 @@ server periodically fetches the newest data.
 
 This index service is offered for free to all developers, and is mostly useful
 to people working on the open-source LLVM project. The service is run on a
-best-effort basis and is not an official LLVM product.
-Google donated the funding for Google Cloud Platform instance that is used, but
-it is a public instance running and serving unmodified LLVM code.
+best-effort basis. Google donated the funding for Google Cloud Platform
+instance that is used, but it is a public instance running and serving
+unmodified LLVM code.
 
 The requests clangd sends to server contain information about the code such as
 the file path you are editing, partial token before the cursor and other


### PR DESCRIPTION
* Add production server address
* Remove mentions of the service being experimental
* Add Remote Index pages to the navbar for better visibility and feature
  discovery (it's almost impossible to find otherwise)