### PR TITLE
Add clangd-12 tag to Index->External in config

### DIFF
--- a/config.md
+++ b/config.md
@@ -145,6 +145,7 @@ This is checked for translation units only, not headers they include.
 Legal values are `Build` (the default) or `Skip`.
 
 ### External
+{:.v12}
 
 Used to define an external index source:
 


### PR DESCRIPTION
Fixes https://github.com/clangd/clangd/issues/650
This is the last entry that is untagged going off the premise that any header tagged with a version should indicate that all its subkeys are also tagged with the same version.