### PR TITLE
Add support for child pages in nav (desktop only). Used for design/

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -14,6 +14,13 @@
 - title: Design
   url: /design/
   icon: '✨'
+  children:
+    - title: Code walkthrough
+      url: /design/code.html
+    - title: Threads & requests
+      url: /design/threads.html
+    - title: The clangd index
+      url: /design/indexing.html
 - title: Protocol extensions
   url: /extensions.html
   icon: '⊕'

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,8 +27,13 @@
       {% if entry == 'separator' %}
         <hr>
       {% else %}
-      <a href="{{entry.url | relative_url}}" class="{%if page.url == entry.url%}selected{%endif%}">
+      <a href="{{entry.url | relative_url}}" class="{%if page.url contains entry.url%}selected{%endif%} {%if entry.children%}folder{%endif%}">
         <span class="icon">{{entry.icon}}</span><span>{{ entry.title }}</span></a>
+        {%if page.url contains entry.url%}
+          {% for child in entry.children %}
+        <a href="{{child.url | relative_url}}" class="child {%if page.url == child.url%}selected{%endif%}">{{child.title}}</a>
+          {% endfor %}
+        {%endif%}
       {% endif %}
     {% endfor %}</nav>
   </aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
         <span class="icon">{{entry.icon}}</span><span>{{ entry.title }}</span></a>
         {%if page.url contains entry.url%}
           {% for child in entry.children %}
-        <a href="{{child.url | relative_url}}" class="child {%if page.url == child.url%}selected{%endif%}">{{child.title}}</a>
+        <a href="{{child.url | relative_url}}" class="child {%if page.url contains child.url%}selected{%endif%}">{{child.title}}</a>
           {% endfor %}
         {%endif%}
       {% endif %}

--- a/styles.css
+++ b/styles.css
@@ -60,12 +60,22 @@ nav a {
   padding: 0.8em 2em;
   /* text ------- [icon] */
   display: flex;
-  flex-direction: row-reverse;
   justify-content: space-between;
   align-items: center;
+  /* use as a parent for absolute positioning */
+  position: relative;
 }
 nav a.selected {
   background-color: rgba(50, 150, 220, 0.3);
+}
+nav a.folder::before {
+  content: "▶";
+  color: #246;
+  position: absolute;
+  left: 0.5em;
+}
+nav a.folder.selected::before {
+  content: "▼";
 }
 nav a:hover:not(.selected) {
   background-color: rgba(50, 150, 220, 0.1);
@@ -79,6 +89,13 @@ nav a .icon {
   width: 1.2em;
   /* Get color emoji if we can */
   font-family: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", Times, Symbola, Aegyptus, Code2000, Code2001, Code2002, Musica, serif, LastResort;
+  order: 1;
+}
+nav a.child {
+  font-weight: 600;
+  padding: 0.4em 3em;
+  display: block;
+  color: #246;
 }
 main {
   padding: 0 4em;
@@ -205,10 +222,14 @@ a[href^="https://code.woboq.org/"] {
   }
   nav a .icon {
     margin-right: 0.1em;
+    order: -1;
   }
   nav hr {
     margin: 0;
   }
+  /* Folders/children are not shown in mini layout */
+  nav a.folder::before { content: none ! important; }
+  nav a.child { display: none; }
   pre { white-space: pre-wrap; }
   code { overflow-wrap: break-word; }
 }

--- a/styles.css
+++ b/styles.css
@@ -69,7 +69,7 @@ nav a.selected {
   background-color: rgba(50, 150, 220, 0.3);
 }
 nav a.folder::before {
-  content: "▶";
+  content: "►";
   color: #246;
   position: absolute;
   left: 0.5em;

--- a/styles.css
+++ b/styles.css
@@ -57,7 +57,7 @@ nav {
   flex-direction: column;
 }
 nav a {
-  padding: 0.8em 2em;
+  padding: 0.8em 1.5em;
   /* text ------- [icon] */
   display: flex;
   justify-content: space-between;
@@ -72,7 +72,7 @@ nav a.folder::before {
   content: "►";
   color: #246;
   position: absolute;
-  left: 0.5em;
+  left: 0.2em;
 }
 nav a.folder.selected::before {
   content: "▼";
@@ -93,9 +93,10 @@ nav a .icon {
 }
 nav a.child {
   font-weight: 600;
-  padding: 0.4em 3em;
+  padding: 0.4em 0.5em;
   display: block;
   color: #246;
+  border-left: 2em solid rgba(0,0,0,0.1);
 }
 main {
   padding: 0 4em;


### PR DESCRIPTION
The idea here is to make it conceptually easier/cheaper to add new pages without affecting the existing nav by "burying" them under sections that are only expanded after being selected.

This is used for the design docs but the mechanism should also be used for user-facing "guides" that can be fairly niche and don't have a good home in the current design.

At least for now these child-pages are accessible through nav only on desktop, so mobile still relies on finding them from the "landing page".

Preview: https://sam-mccall.github.io/clangd-www/