### PR TITLE
Move remote index docs under design

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ plugins:
 - jekyll-optional-front-matter
 - jekyll-default-layout
 - jekyll-titles-from-headings
+- jekyll-redirect-from
 markdown: kramdown
 kramdown:
   parse_block_html: true

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -21,13 +21,12 @@
       url: /design/threads.html
     - title: The clangd index
       url: /design/indexing.html
+    - title: Remote index
+      url: /design/remote-index.html
 - title: Protocol extensions
   url: /extensions.html
   icon: '⊕'
 - separator
-- title: Remote Index
-  url: /remote-index.html
-  icon: '💻'
 - title: LLVM Remote Index service
   url: /llvm-remote-index.html
   icon: '🐲'

--- a/design/remote-index.md
+++ b/design/remote-index.md
@@ -1,3 +1,7 @@
+---
+redirect_from: /remote-index
+redirect_from: /remote-index.html
+---
 # Remote index
 
 A [project-wide index](/design/indexing.html) can be slow to build, particularly

--- a/llvm-remote-index.md
+++ b/llvm-remote-index.md
@@ -1,6 +1,6 @@
 # LLVM remote index service
 
-A clangd [remote index](/remote-index.html) server for the [LLVM
+A clangd [remote index](/design/remote-index.html) server for the [LLVM
 project](https://github.com/llvm/llvm-project) is currently available at
 [clangd-index.llvm.org](http://clangd-index.llvm.org/).
 
@@ -19,7 +19,7 @@ Index:
 ```
 
 For more details on remote index configuration, see [remote
-index](/remote-index.html).
+index](/design/remote-index.html).
 
 ## Overview
 


### PR DESCRIPTION
Also set up redirections so we don't break existing links

(TODO: split out user-facing part into guides, and inline the LLVM
remote index page)