### PR TITLE
change clang-tidy config

### DIFF
--- a/config.md
+++ b/config.md
@@ -202,7 +202,7 @@ Diagnostic codes that should be suppressed.
 
 Valid values are:
 
-- `*`, to disable all diagnostics
+- `'*'`, to disable all diagnostics
 - diagnostic codes exposed by clangd (e.g `unknown_type`, `-Wunused-result`)
 - clang internal diagnostic codes (e.g. `err_unknown_type`)
 - warning categories (e.g. `unused-result`)

--- a/config.md
+++ b/config.md
@@ -222,6 +222,7 @@ configuration files with the ones from clangd configs taking precedence.
 #### Add
 
 List of checks to enable, can be globs.
+To enable all available checks use `Add: '*'`.
 
 #### Remove
 

--- a/config.md
+++ b/config.md
@@ -221,8 +221,8 @@ configuration files with the ones from clangd configs taking precedence.
 
 #### Add
 
-List of checks to enable, can be globs.
-To enable all available checks use `Add: '*'`.
+List of [checks](https://clang.llvm.org/extra/clang-tidy/checks/list.html).
+These can be globs, for example `Add: 'bugprone-*'`.
 
 #### Remove
 


### PR DESCRIPTION
While creating a new clang-tidy check or using most of the available clang-tidy check modules,
it could be useful to activate all possible checks and remove a few unwanted ones.

By doing so, it seems that this only works with the clangd configuration style (config.yaml or .clangd)
by wrapping `*` in single quotes, like it would be done in a .clang-tidy file.

```
Diagnostics:
  ClangTidy:
    Add: '*'
```

The clangd documentation shows that `Add: modernize*` is a valid configuration.
In my opinion, this implies that `Add: *` is also valid, which is not the case.
It generates a "Got empty alias or anchor" error, which I believe comes from the YAMLParser.cpp file.

To make this edge case clearer, I recommend updating the configuration page as shown in this pull request.