### PR TITLE
Update latest version to 12.0 in installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -10,7 +10,7 @@ To use clangd, you need:
 
 You'll want a **recent** version of clangd. The current release is 12.0.
 
-After installing, `clangd --version` should print `clangd version 7.0.0` or later.
+After installing, `clangd --version` should print `clangd version 12.0.1` or later.
 
 (Version numbers are based on LLVM. clangd 7 was the first usable release).
 

--- a/installation.md
+++ b/installation.md
@@ -8,7 +8,7 @@ To use clangd, you need:
 
 ## Installing clangd
 
-You'll want a **recent** version of clangd. The current release is 11.0.
+You'll want a **recent** version of clangd. The current release is 12.0.
 
 After installing, `clangd --version` should print `clangd version 7.0.0` or later.
 
@@ -41,19 +41,19 @@ Download the LLVM installer from [releases.llvm.org](http://releases.llvm.org/do
 <summary markdown="span">Debian/Ubuntu</summary>
 Installing the `clangd` package will usually give you a slightly older version.
 
-Try to install the latest packaged release (9.0):
+Try to install the latest packaged release (12.0):
 
 ```bash
-sudo apt-get install clangd-9
+sudo apt-get install clangd-12
 ```
 
 If that's not found, at least `clangd-9` or `clangd-8` should be available.
 Versions before 8 were part of the `clang-tools` package.
 
-This will install clangd as `/usr/bin/clangd-9`. Make it the default `clangd`:
+This will install clangd as `/usr/bin/clangd-12`. Make it the default `clangd`:
 
 ```bash
-sudo update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-9 100
+sudo update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-12 100
 ```
 
 </details>


### PR DESCRIPTION
The latest release of LLVM is 12.0 now, so we could also update the latest version of clangd to 12.0 in installation.md