### PR TITLE
FAQ: Fix example usage of CompilationDatabase key

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -117,7 +117,8 @@ In clangd 12 and later, this can be done by adding the following to your
 [clangd config file](https://clangd.llvm.org/config.html):
 
 ```yaml
-CompilationDatabase: <path>
+CompileFlags:
+  CompilationDatabase: <path>
 ```
 
 where `<path>` is the directory containing the compilation database.


### PR DESCRIPTION
The example was misleading, suggesting that it's a top-level key,
when in fact it's a sub-key under CompileFlags.