### PR TITLE
Compilation Database: Point Bazel users to a solution

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -288,6 +288,11 @@ ln -s ~/myproject/compile_commands.json ~/myproject-build/
 </details>
 
 <details>
+<summary markdown="span">Bazel-based projects</summary>
+Bazel can generate this file via [this extractor extension](https://github.com/hedronvision/bazel-compile-commands-extractor). Refer to instructions in the project README; it is intended for use with clangd. 
+</details>
+
+<details>
 <summary markdown="span">Other build systems, using Bear</summary>
 [Bear](https://github.com/rizsotto/Bear) is a tool to generate a
 compile_commands.json file by recording a complete build.


### PR DESCRIPTION
This doc lists ways of getting compilation databases out of some popular build systems for use with clangd. 

We built such a way for Bazel and just released it after a bunch of requests on GitHub. I'd [proposed adding it to the llvm compile_commands.json docs](https://reviews.llvm.org/D114213), and folks suggested we also add it here.

Thanks for your consideration--and the most wonderful of tools.