### PR TITLE
Point to github discussions instead of discourse

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -53,7 +53,7 @@
   url: https://github.com/clangd/clangd/issues
   icon: '🐞'
 - title: Forum
-  url: https://llvm.discourse.group/c/llvm-project/clangd/34
+  url: https://github.com/clangd/clangd/discussions
   icon: '💡'
 - title: Chat (#clangd)
   url: https://discord.gg/xS7Z362


### PR DESCRIPTION
WDYT?

Rate of traffic to GH discussions is only a little lower despite no links.
- https://github.com/clangd/clangd/discussions
- https://llvm.discourse.group/c/llvm-project/clangd/34
Fewer login systems for people to deal with, more "in one place".