### PR TITLE
Redirect remote-index links to Guides instead of Design

### DIFF
--- a/design/indexing.md
+++ b/design/indexing.md
@@ -91,4 +91,4 @@ Remote index allows serving index on a separate machine and connecting to it
 from your device. This means you don't have to build the index yourself
 anymore and clangd will use significantly less memory. Hence developers can
 work from less powerful machines, while still using clangd to its fullest.
-For more details, see [remote index](/remote-index).
+For more details, see [remote index](/design/remote-index).

--- a/design/remote-index.md
+++ b/design/remote-index.md
@@ -1,7 +1,3 @@
----
-redirect_from: /remote-index
-redirect_from: /remote-index.html
----
 # Remote index
 
 A [project-wide index](/design/indexing) can be slow to build, particularly

--- a/guides/remote-index.md
+++ b/guides/remote-index.md
@@ -1,6 +1,8 @@
 ---
 redirect_from: /llvm-remote-index
 redirect_from: /llvm-remote-index.html
+redirect_from: /remote-index
+redirect_from: /remote-index.html
 ---
 # Using a remote index
 


### PR DESCRIPTION
Completely resolves #63.