### PR TITLE
Fix an incorrect example in the FAQ

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -86,12 +86,12 @@ Index:
 
 If you have some headers outside of the visibility of clangd, you can either
 include individual headers (`-include=/headers/file.h`) or add
-directories to the include path (`-I=/other/headers`). The easiest way to do
+directories to the include path (`-I/other/headers`). The easiest way to do
 that is through configuration file:
 
 ```yaml
 CompileFlags:
-  Add: [-include=/headers/file.h, -I=/other/headers]
+  Add: [-include=/headers/file.h, -I/other/headers]
 ```
 
 ## Why does clangd not return all references for a symbol?


### PR DESCRIPTION
The example used -I=path as an compile flag to add, but -I
does not support '=' as a separator.

Fixes https://github.com/clangd/clangd/issues/1150