### PR TITLE
Add margin at the bottom of "Main article:" boxes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -222,7 +222,7 @@ main h1, main h2, main h3, main h4 {
   font-style: italic;
   background-color: rgba(0,0,0,0.05);
   padding: 0.3em 0;
-  margin: -0.5em 0;
+  margin: -0.5em 0 0.5em;
   text-decoration: none;
 }
 .main-article::before {


### PR DESCRIPTION
This fixes the issue when the bottom "Main article:" box may be displayed partially outside of the parent `<main>` element. The issue can be observed on [Design of clangd](https://clangd.llvm.org/design/) page.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/25753618/193803376-73be731a-1e06-4ef3-8c1c-dd21ecc6685e.png)|![image](https://user-images.githubusercontent.com/25753618/193803483-8b00fd16-d677-4518-83e8-3425e952505d.png)|

Note that spacing between the rest of "Main article:" boxes and subsequent headings increases as well, slightly bloating the page vertically. I hope it is acceptable.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/25753618/193804053-8a72d1c9-d3ce-488d-9007-3b6e3933516e.png)|![image](https://user-images.githubusercontent.com/25753618/193804095-09c0a085-d779-429d-b037-701ac5d6bde4.png)|
