### PR TITLE
Add Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+tasks:
+  - before: |-
+      export
+      GEM_HOME=/workspace/gems
+      PATH=$GEM_HOME/bin:$PATH
+    init: gem install github-pages
+    command: jekyll serve
+
+ports:
+  - port: 4000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ jekyll serve
 ```
 
 The instance at http://localhost:4000/ will refresh when you edit any file.
+
+Or you can simply just
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/llvm/clangd-www)


### PR DESCRIPTION
I have already used [Gitpod](https://www.gitpod.io) a couple of times to contribute to this repo, so I decided to add a proper configuration so that `gem install ...` and `jekyll serve` commands no longer need to be copied from readme or typed manually.