### PR TITLE
Advertise Markdown files as "source" files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
This change makes Markdown files ["detectable"](https://github.com/github/linguist/blob/master/docs/overrides.md#detectable) by Github as "source" files. As a result, these files will be accounted in repo's language stats.
![image](https://user-images.githubusercontent.com/25753618/194568368-22a952e5-c37d-4781-9d00-a8cba472a3d7.png)
Markdown will become the main language of the repo.
![image](https://user-images.githubusercontent.com/25753618/194568582-aeb3d8cc-3779-4455-8acb-9bdb1d3d1da2.png)
This seems fair given that readme says:
> Usually you won't need more than GitHub's markdown preview feature.