### PR TITLE
Add path usage example in If section

### DIFF
--- a/config.md
+++ b/config.md
@@ -69,7 +69,9 @@ e.g. `PathMatch: [foo/.*, bar/.*]` matches files in either directory.
 
 Conditions based on a file's path use the following form:
 
-- if the fragment came from a project directory, the path is relative
+- if the fragment came from a project directory, the path is relative  
+(note: `./dir/.*` is an incorrect form for `dir` content in the project's root
+from the regex perspective, use `dir/.*` instead)
 - if the fragment is global (e.g. user config), the path is absolute
 - paths always use forward-slashes (UNIX-style)
 


### PR DESCRIPTION
I've added path usage example as discussed with @HighCommander4 [here](https://github.com/clangd/clangd/discussions/1382#discussioncomment-4257902).
The page fragment:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/23224148/204853531-9d2b0f70-98fb-4bd5-b31a-48d3ea203eac.png">

