### PR TITLE
Correct version info for 'missing includes' feature

### DIFF
--- a/guides/include-cleaner.md
+++ b/guides/include-cleaner.md
@@ -45,7 +45,7 @@ This isn't always the case: the analysis makes assumptions about code style.
 
 ## "Missing include" warning
 
-{:.v16}
+{:.v17}
 
 Similarly, using symbols from a header without `#include`ing it is brittle and
 hides dependencies. clangd can show such uses:

--- a/styles.css
+++ b/styles.css
@@ -168,7 +168,7 @@ a[href^="https://code.woboq.org/"] {
 }
 
 /* Version marker ornaments */
-.v6::before, .v7::before, .v8::before, .v9::before, .v10::before, .v11::before, .v12::before, .v13::before, .v14::before, .v15::before, .v16::before {
+.v6::before, .v7::before, .v8::before, .v9::before, .v10::before, .v11::before, .v12::before, .v13::before, .v14::before, .v15::before, .v16::before, .v17::before {
   color: #008;
   border-radius: 3px;
   padding: 0.2em 0.6em;
@@ -191,6 +191,7 @@ a[href^="https://code.woboq.org/"] {
 .v14::before { content: "clangd-14"; }
 .v15::before { content: "clangd-15"; }
 .v16::before { content: "clangd-16"; }
+.v17::before { content: "clangd-17"; }
 #edit {
   text-decoration: none;
   position: absolute;


### PR DESCRIPTION
The feature was added in https://reviews.llvm.org/D143496, which was merged after the 16.x branch cut and was not backported to the 16.x branch, thus it's only available in clangd 17.