### PR TITLE
Explicitly call out MinGW as needing --query-driver

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -53,8 +53,8 @@ paths were searched for the standard library. You can compare this to the output
 of `clang -### <args>`.
 
 If you're using an unusual compiler (e.g. a cross-compiler for a different
-platform) you may want to pass `--query-driver=/path/to/mygcc` or
-`--query-driver=/path/to/mygcc,/path/to/myg++` when using C++ to allow clangd
+platform, or MinGW on Windows) you may want to pass `--query-driver=/path/to/mygcc`
+or `--query-driver=/path/to/mygcc,/path/to/myg++` when using C++ to allow clangd
 to extract the include paths from it directly.
 
 ### Can't find compiler built-in headers (`<stddef.h>` etc)


### PR DESCRIPTION
Based on experience answering hundreds of users questions, users don't tend to think of MinGW as "unusual" or a "cross-compiler", but it does seem to require use of --query-driver to work well.