### PR TITLE
Fix syntax for including individual header in FAQ

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -85,13 +85,13 @@ Index:
 ## How do I make additional headers visible to clangd?
 
 If you have some headers outside of the visibility of clangd, you can either
-include individual headers (`-include=/headers/file.h`) or add
+include individual headers (`--include=/headers/file.h`) or add
 directories to the include path (`-I/other/headers`). The easiest way to do
 that is through configuration file:
 
 ```yaml
 CompileFlags:
-  Add: [-include=/headers/file.h, -I/other/headers]
+  Add: [--include=/headers/file.h, -I/other/headers]
 ```
 
 ## Why does clangd not return all references for a symbol?


### PR DESCRIPTION
At https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-include-file, you can see that only `--include` supports being used like `--include=foo.h`. `-include` can only be used like `-includefoo.h`, and so trying to follow the instructions and use `-include=*` doesn't do anything.

I'm kind of surprised that I didn't get any errors trying to use `-include=*`, `clangd` seems to be suppressing them or something.