### PR TITLE
docs: typo on lspconfig init_options

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -174,7 +174,7 @@ local lspconfig = require('lspconfig')
 lspconfig.clangd.setup({
   name = 'clangd',
   cmd = {'clangd', '--background-index', '--clang-tidy', '--log=verbose'},
-  initialization_options = {
+  init_options = {
     fallback_flags = { '-std=c++17' },
   },
 })


### PR DESCRIPTION
there is no initialization_options field in lspconfig