### PR TITLE
docs: fix typo

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -175,7 +175,7 @@ local lspconfig = require('lspconfig')
 lspconfig.clangd.setup({
   cmd = {'clangd', '--background-index', '--clang-tidy', '--log=verbose'},
   init_options = {
-    fallback_flags = { '-std=c++17' },
+    fallbackFlags = { '-std=c++17' },
   },
 })
 ```


### PR DESCRIPTION
sry for typo there should be `fallbackFlags`