### PR TITLE
Update default value of StandardLibrary config key to Yes

### DIFF
--- a/config.md
+++ b/config.md
@@ -224,7 +224,7 @@ code completions of standard library symbols on an empty file). Sample block
 
 ```
 Index:
-  StandardLibrary: No
+  StandardLibrary: Yes
 ```
 
 ## Style


### PR DESCRIPTION
The default has been Yes since https://github.com/llvm/llvm-project/commit/79ed24eea37f00b02d427f8ca59570546a5037a4.