### PR TITLE
Add documentation for the config option "Documentation"

### DIFF
--- a/config.md
+++ b/config.md
@@ -537,7 +537,7 @@ Specify semantic token modifiers that clangd should not send to client.
 Available modifiers could be found [here](features#modifiers) in the Modifier column.
 
 ## Documentation
-{:.v21}
+{:.v22}
 
 Specify server side documentation code comment interpretation.
 Affects the format of the documentation string sent to the client for hover and code completions.
@@ -554,4 +554,4 @@ Determines the comment format of code documentation.
 
 - `PlainText`: interpret code documentation as plain text. Markdown specific syntax will be escaped. On clients supporting markdown, this will result in showing markdown syntax without rendering. E.g. using \*\*bold text\*\* in the documentation comment will be shown as \*\*bold text\*\* and not as **bold text** in the hover/code completion.
 - `Markdown`: interpret documentation comments as markdown. Markdown syntax will not be escaped, except for HTML tags. On clients supporting markdown, this will result in rendering all markdown syntax.
-- `Doxygen`: interpret code documentation as [doxygen](https://www.doxygen.nl/) comments. In addition to treating the documentation as markdown, this will parse the documentation with Clangs doxygen parser. It will highlight used doxygen commands, convert doxygen commands to markdown syntax and extend hover content with e.g. function parameter or return documentation.
+- `Doxygen`: interpret code documentation as [doxygen](https://www.doxygen.nl/) comments. In addition to treating the documentation as markdown, this will parse the documentation with Clang's doxygen parser. It will highlight used doxygen commands, convert doxygen commands to markdown syntax and extend hover content with e.g. function parameter or return documentation.

--- a/config.md
+++ b/config.md
@@ -535,3 +535,23 @@ Available kinds could be found [here](features#kinds) in the Kind column.
 Specify semantic token modifiers that clangd should not send to client.
 
 Available modifiers could be found [here](features#modifiers) in the Modifier column.
+
+## Documentation
+{:.v21}
+
+Specify server side documentation code comment interpretation.
+Affects the format of the documentation string sent to the client for hover and code completions.
+Sample block (default):
+
+```yaml
+Documentation:
+  CommentFormat: PlainText
+```
+
+### CommentFormat
+
+Determines the comment format of code documentation.
+
+- `PlainText`: interpret code documentation as plain text. Markdown specific syntax will be escaped. On clients supporting markdown, this will result in showing markdown syntax without rendering. E.g. using \*\*bold text\*\* in the documentation comment will be shown as \*\*bold text\*\* and not as **bold text** in the hover/code completion.
+- `Markdown`: interpret documentation comments as markdown. Markdown syntax will not be escaped, except for HTML tags. On clients supporting markdown, this will result in rendering all markdown syntax.
+- `Doxygen`: interpret code documentation as [doxygen](https://www.doxygen.nl/) comments. In addition to treating the documentation as markdown, this will parse the documentation with Clangs doxygen parser. It will highlight used doxygen commands, convert doxygen commands to markdown syntax and extend hover content with e.g. function parameter or return documentation.

--- a/styles.css
+++ b/styles.css
@@ -170,7 +170,7 @@ a[href^="https://code.woboq.org/"] {
 /* Version marker ornaments */
 .v6::before, .v7::before, .v8::before, .v9::before, .v10::before, .v11::before, .v12::before,
 .v13::before, .v14::before, .v15::before, .v16::before, .v17::before, .v18::before, .v19::before,
-.v20::before, .v21::before {
+.v20::before, .v21::before, .v22::before {
   color: #008;
   border-radius: 3px;
   padding: 0.2em 0.6em;
@@ -198,6 +198,7 @@ a[href^="https://code.woboq.org/"] {
 .v19::before { content: "clangd-19"; }
 .v20::before { content: "clangd-20"; }
 .v21::before { content: "clangd-21"; }
+.v22::before { content: "clangd-22"; }
 #edit {
   text-decoration: none;
   position: absolute;


### PR DESCRIPTION
The `Documentation` config option was added with llvm/llvm-project#140498 which is related to clangd/clangd#529.