### PR TITLE
Update Bear guidance on the installation page

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -413,7 +413,7 @@ Bazel can generate this file via [this extractor extension](https://github.com/h
 <details>
 <summary markdown="span">Other build systems, using Bear</summary>
 [Bear](https://github.com/rizsotto/Bear) is a tool to generate a
-compile_commands.json file by recording a complete build. It works with
+`compile_commands.json` file by recording a complete build. It works with
 any build system that runs a compiler (make, autotools, custom scripts,
 ...), recognizes a wide range of toolchains (GCC, Clang, MSVC, and many
 cross, embedded, and HPC compilers), and runs on Linux, macOS, Windows,

--- a/installation.md
+++ b/installation.md
@@ -413,11 +413,15 @@ Bazel can generate this file via [this extractor extension](https://github.com/h
 <details>
 <summary markdown="span">Other build systems, using Bear</summary>
 [Bear](https://github.com/rizsotto/Bear) is a tool to generate a
-compile_commands.json file by recording a complete build.
+compile_commands.json file by recording a complete build. It works with
+any build system that runs a compiler (make, autotools, custom scripts,
+...), recognizes a wide range of toolchains (GCC, Clang, MSVC, and many
+cross, embedded, and HPC compilers), and runs on Linux, macOS, Windows,
+and the BSDs.
 
 For a `make`-based build, you can run 
-- `make clean; bear -- make` (for bear 3.0.x versions)
-- `make clean; bear make` (for bear 2.4.x versions)
+- `make clean; bear -- make` (bear 3.0 and later)
+- `make clean; bear make` (bear 2.4.x, still shipped by some distributions)
 
 to generate the file (and run a clean build!).
 


### PR DESCRIPTION
Two small updates to the Bear entry in the compilation-database section:

- The `bear -- make` syntax applies to Bear 3.0 and all later versions
  (including the current 4.x line), so the version labels now say that
  instead of "3.0.x". The 2.4.x form is kept, since some distributions
  still ship that release.
- The introductory sentence now says which build systems, toolchains,
  and operating systems Bear covers, so readers can tell whether it
  applies to their setup before trying it.

I am Bear's maintainer; happy to adjust the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)